### PR TITLE
Enable Ray parallel envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,21 @@
 # 🏎️ CarRacing-v3 Agent with Deep Q-Learning
 
 This project implements a Deep Q-Network (DQN) agent to solve the [CarRacing-v3](https://www.gymlibrary.dev/environments/box2d/car_racing/) environment from Gymnasium. The agent learns from pixel observations using frame stacking, reward clipping, experience replay, and softmax or epsilon-greedy exploration strategies.
+For scalable training, the code also provides an optional Ray-based vector environment.
 
 ---
 
 ## 📂 Project Structure
 ```text
 .
-├── run.py               # Main training script
-├── agent.py             # Agent logic (Deep Q-learning)
-├── buffer.py            # Replay buffer for experience replay
-├── car_racing_env.py    # Preprocessing wrapper for CarRacing-v3
-├── exploration.py       # Exploration strategies
-└── neural_network.py    # Q-network
+├── train.py            # Main training script
+├── agent.py            # Agent logic (Deep Q-learning)
+├── buffer.py           # Replay buffer for experience replay
+├── car_racing_env.py   # Preprocessing wrapper for CarRacing-v3
+├── exploration.py      # Exploration strategies
+├── model.py            # Q-network
+├── ray_env.py          # Optional Ray-based vector environment
+└── config.yaml         # Training configuration
 ```
 ---
 
@@ -21,17 +24,17 @@ This project implements a Deep Q-Network (DQN) agent to solve the [CarRacing-v3]
 ### 1. Install Dependencies
 
 ```bash
-pip install swig gymnasium[box2d] imageio imageio-ffmpeg
+pip install swig gymnasium[box2d] imageio imageio-ffmpeg ray
 ```
 
 ### 2. Train the Agent
 
 ```bash
-python run.py
+python train.py --config config.yaml
 ```
 
 This will:
-- Train the agent using AsyncVectorEnv (default: 10 environments)
+- Train the agent using `AsyncVectorEnv` (default) or `RayVectorEnv` when `use_ray: true`
 - Evaluate the policy every epoch
 - Save the best model as `best_model` variable
 - Save a video of the best-performing episode in the `videos/` folder

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,5 @@
 num_envs: 5
+use_ray: false
 num_epochs: 20
 epoch_steps: 5000
 eval_interval: 1

--- a/ray_env.py
+++ b/ray_env.py
@@ -1,0 +1,55 @@
+import numpy as np
+import ray
+
+from car_racing_env import CarRacingEnv
+
+
+@ray.remote
+class EnvWorker:
+    def __init__(self):
+        self.env = CarRacingEnv()
+
+    def reset(self, seed=None):
+        return self.env.reset(seed=seed)
+
+    def step(self, action):
+        return self.env.step(action)
+
+    def close(self):
+        self.env.close()
+
+
+class RayVectorEnv:
+    """Simple vectorized environment using Ray actors."""
+
+    def __init__(self, num_envs):
+        ray.init(ignore_reinit_error=True)
+        self.num_envs = num_envs
+        self.workers = [EnvWorker.remote() for _ in range(num_envs)]
+
+        temp_env = CarRacingEnv()
+        self.single_observation_space = temp_env.observation_space
+        self.single_action_space = temp_env.action_space
+        temp_env.close()
+
+    def reset(self, seed=None):
+        seeds = [None] * self.num_envs if seed is None else [seed + i for i in range(self.num_envs)]
+        results = ray.get([w.reset.remote(seed=s) for w, s in zip(self.workers, seeds)])
+        states, infos = zip(*results)
+        return np.stack(states), list(infos)
+
+    def step(self, actions):
+        results = ray.get([w.step.remote(a) for w, a in zip(self.workers, actions)])
+        states, rewards, terminateds, truncateds, infos = zip(*results)
+        return (
+            np.stack(states),
+            np.array(rewards, dtype=np.float32),
+            np.array(terminateds, dtype=np.float32),
+            np.array(truncateds, dtype=np.float32),
+            list(infos),
+        )
+
+    def close(self):
+        for w in self.workers:
+            w.close.remote()
+        ray.shutdown()


### PR DESCRIPTION
## Summary
- add a Ray-based vector environment implementation
- allow `train.py` to optionally use Ray
- expose `use_ray` option in `config.yaml`
- document Ray usage in the README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684251ce8ac8832b8075918682308f84