### PR TITLE
Add seed utility, saving, and memory optimized buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,36 @@ This will:
 ### 4. Evaluation
 - After training, the script evaluates the best model on 10 random seeds and saves the best rollout as an .mp4 file for qualitative analysis.
 
+### 5. Recommended Hyperparameters
+
+```yaml
+DQN:
+  lr: [1e-4, 5e-4]
+  gamma: [0.98, 0.999]
+  batch_size: [32, 64]
+  warmup_steps: [5000, 10000]
+  buffer_size: [100000, 500000]
+  target_update_interval: [5000, 10000]
+  use_double_q: [true, false]
+
+PPO:
+  lr: [1e-4, 3e-4]
+  gamma: [0.98, 0.99]
+  gae_lambda: [0.9, 0.95]
+  clip_eps: [0.1, 0.2]
+  update_epochs: [4, 10]
+  batch_size: [32, 64]
+
+SAC:
+  lr: [1e-4, 3e-4]
+  gamma: [0.98, 0.99]
+  tau: [0.005, 0.01]
+  alpha: [0.1, 0.2]
+  batch_size: [256, 512]
+  buffer_size: [100000, 1000000]
+  warmup_steps: [1000, 5000]
+```
+
 📌 Acknowledgments
 - Built using OpenAI Gymnasium
 - Inspired by DQN and classic Atari RL pipelines

--- a/agent.py
+++ b/agent.py
@@ -39,7 +39,7 @@ class Agent:
 
         obs_space = spaces.Box(low=0.0, high=1.0, shape=state_dim, dtype=np.float32)
         act_space = spaces.Discrete(action_dim)
-        self.buffer = ReplayBuffer(buffer_size, obs_space, act_space, device=self.device)
+        self.buffer = ReplayBuffer(buffer_size, obs_space, act_space, device=self.device, use_uint8=True)
 
         self.total_steps = 0
         self.exploration_strategy = exploration_strategy

--- a/sac_agent.py
+++ b/sac_agent.py
@@ -86,7 +86,7 @@ class SACAgent:
         self.critic1_opt = torch.optim.Adam(self.critic1.parameters(), lr=lr)
         self.critic2_opt = torch.optim.Adam(self.critic2.parameters(), lr=lr)
 
-        self.buffer = ReplayBuffer(buffer_size, observation_space, action_space, device=self.device)
+        self.buffer = ReplayBuffer(buffer_size, observation_space, action_space, device=self.device, use_uint8=True)
 
     def act(self, obs, deterministic: bool = False):
         obs_t = torch.as_tensor(obs, dtype=torch.float32, device=self.device).unsqueeze(0)

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,12 @@
+import random
+import numpy as np
+import torch
+
+def set_seed(seed: int) -> None:
+    """Set random seed for `random`, `numpy`, and `torch`."""
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+


### PR DESCRIPTION
## Summary
- add a global `set_seed` helper
- store observations in replay buffer using uint8 to save memory
- make agents use the new memory efficient buffer
- record training history as `history.json`
- set seed at startup
- document recommended hyperparameter ranges

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68500ca2b628832ba5a042c5d534cce8