### PR TITLE
Use Ray Tune for HPO

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🏎️ CarRacing-v3 Agents
 
-This project provides both a Deep Q-Network (DQN) agent and a lightweight PPO actor-critic agent. Each learns from stacked pixel observations, and training can optionally use a Ray-based vector environment. The DQN implementation now relies on an Atari-style CNN backbone for processing frames.
+This project provides both a Deep Q-Network (DQN) agent and a lightweight PPO actor-critic agent. Each learns from stacked pixel observations, and training can optionally use a Ray-based vector environment. The DQN implementation now uses a CNN tuned for 4×84×84 inputs.
 
 ---
 
@@ -24,7 +24,7 @@ This project provides both a Deep Q-Network (DQN) agent and a lightweight PPO ac
 ### 1. Install Dependencies
 
 ```bash
-pip install swig gymnasium[box2d] imageio imageio-ffmpeg ray
+pip install swig gymnasium[box2d] imageio imageio-ffmpeg ray[tune] pyyaml
 ```
 
 ### 2. Train the Agent
@@ -37,22 +37,33 @@ python train.py --config ppo_config.yaml  # Proximal Policy Optimization
 python train.py --config sac_config.yaml  # Soft Actor-Critic
 ```
 
+The DQN agent uses a prioritized replay buffer by default for more efficient learning.
+
+### 3. Hyperparameter Optimization
+
+Add `--hpo` to automatically explore recommended hyperparameters using **Ray Tune**.
+Results can be logged to Weights & Biases with `--wandb_project <project>`.
+
+```bash
+python train.py --config dqn_config.yaml --hpo --wandb_project car_racing
+```
+
 This will:
 - Train the agent using `AsyncVectorEnv` (default) or `RayVectorEnv` when `use_ray: true`
 - Evaluate the policy every epoch
 - Save the best model as `best_model` variable
 - Save a video of the best-performing episode in the `videos/` folder
 
-### 3. Environment Details
+### 4. Environment Details
 - Environment: CarRacing-v3 (discrete mode)
 - Observation: 4 stacked grayscale frames (4x84×84)
 - Action space: 5 discrete actions (left, right, gas, brake, no-op)
 - Preprocessing: crop, resize, grayscale, normalize
 
-### 4. Evaluation
+### 5. Evaluation
 - After training, the script evaluates the best model on 10 random seeds and saves the best rollout as an .mp4 file for qualitative analysis.
 
-### 5. Recommended Hyperparameters
+### 6. Recommended Hyperparameters
 
 ```yaml
 DQN:

--- a/buffer.py
+++ b/buffer.py
@@ -468,6 +468,7 @@ class PrioritizedReplayBuffer(ReplayBuffer):
         device: Union[torch.device, str] = "auto",
         n_envs: int = 1,
         optimize_memory_usage: bool = False,
+        use_uint8: bool = False,
         alpha: float = 0.6,
         beta: float = 0.4,
         beta_increment: float = 1e-6,
@@ -480,6 +481,7 @@ class PrioritizedReplayBuffer(ReplayBuffer):
             device=device,
             n_envs=n_envs,
             optimize_memory_usage=optimize_memory_usage,
+            use_uint8=use_uint8,
         )
 
         self.alpha = alpha

--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,7 @@ eval_interval: 1
 eval_episodes: 10
 model_dir: models
 agent_type: DQN
+seed: 42
 
 env:
   continuous: false
@@ -24,3 +25,4 @@ agent:
   buffer_size: 100000
   target_update_interval: 10000
   use_double_q: true
+  prioritized: true

--- a/dqn_config.yaml
+++ b/dqn_config.yaml
@@ -6,6 +6,7 @@ eval_interval: 1
 eval_episodes: 10
 model_dir: dqn_models
 agent_type: DQN
+seed: 42
 
 env:
   continuous: false
@@ -24,3 +25,4 @@ agent:
   buffer_size: 100000
   target_update_interval: 10000
   use_double_q: true
+  prioritized: true

--- a/model.py
+++ b/model.py
@@ -10,12 +10,17 @@ class AtariCNN(nn.Module):
     def __init__(self, input_shape):
         super().__init__()
         c, h, w = input_shape
+        # The original DQN architecture used large strides which can discard
+        # fine-grained details.  For 84×84 inputs with 4 stacked frames we use
+        # slightly smaller strides to retain more spatial resolution.
         self.cnn = nn.Sequential(
-            nn.Conv2d(c, 32, kernel_size=8, stride=4),
+            nn.Conv2d(c, 32, kernel_size=5, stride=2),  # 84 -> 40
             nn.ReLU(),
-            nn.Conv2d(32, 64, kernel_size=4, stride=2),
+            nn.Conv2d(32, 64, kernel_size=5, stride=2),  # 40 -> 18
             nn.ReLU(),
-            nn.Conv2d(64, 64, kernel_size=3, stride=1),
+            nn.Conv2d(64, 64, kernel_size=3, stride=2),  # 18 -> 8
+            nn.ReLU(),
+            nn.Conv2d(64, 64, kernel_size=3, stride=1),  # 8 -> 6
             nn.ReLU(),
             nn.Flatten(),
         )
@@ -34,7 +39,7 @@ class AtariCNN(nn.Module):
         return self.linear(x)
 
 class QNetwork(nn.Module):
-    """Deep Q-Network with an Atari-style CNN backbone."""
+    """Deep Q-Network using the custom CNN feature extractor."""
 
     def __init__(self, state_dim, action_dim):
         super().__init__()

--- a/ppo_config.yaml
+++ b/ppo_config.yaml
@@ -6,6 +6,7 @@ eval_interval: 1
 eval_episodes: 10
 model_dir: ppo_models
 agent_type: PPO
+seed: 42
 
 env:
   continuous: false

--- a/sac_config.yaml
+++ b/sac_config.yaml
@@ -6,6 +6,7 @@ eval_interval: 1
 eval_episodes: 10
 model_dir: sac_models
 agent_type: SAC
+seed: 42
 
 env:
   continuous: true


### PR DESCRIPTION
## Summary
- clarify install instructions
- use Ray Tune for grid-search HPO
- use prioritized replay buffer for DQN
- improve the CNN architecture for 4x84x84 inputs

## Testing
- `python -m py_compile train.py agent.py ppo_agent.py sac_agent.py car_racing_env.py exploration.py model.py buffer.py utils.py ray_env.py`
- `python train.py --help` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_685016e9f438832bba531412c40ef7fe