### PR TITLE
Expose Ray Tune resources_per_trial

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ The DQN agent uses a prioritized replay buffer by default for more efficient lea
 
 Add `--hpo` to automatically explore recommended hyperparameters using **Ray Tune**.
 Results can be logged to Weights & Biases with `--wandb_project <project>`.
+Resource allocation for each Tune trial can be adjusted via a `resources_per_trial` section in the config file.
+
+```yaml
+resources_per_trial:
+  cpu: 1
+  gpu: 0
+```
 
 ```bash
 python train.py --config dqn_config.yaml --hpo --wandb_project car_racing

--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,11 @@ model_dir: models
 agent_type: DQN
 seed: 42
 
+# Resources for Ray Tune trials (optional)
+resources_per_trial:
+  cpu: 1
+  gpu: 0
+
 env:
   continuous: false
 

--- a/dqn_config.yaml
+++ b/dqn_config.yaml
@@ -8,6 +8,11 @@ model_dir: dqn_models
 agent_type: DQN
 seed: 42
 
+# Resources for Ray Tune trials (optional)
+resources_per_trial:
+  cpu: 1
+  gpu: 0
+
 env:
   continuous: false
 

--- a/ppo_config.yaml
+++ b/ppo_config.yaml
@@ -8,6 +8,11 @@ model_dir: ppo_models
 agent_type: PPO
 seed: 42
 
+# Resources for Ray Tune trials (optional)
+resources_per_trial:
+  cpu: 1
+  gpu: 0
+
 env:
   continuous: false
 

--- a/sac_config.yaml
+++ b/sac_config.yaml
@@ -8,6 +8,11 @@ model_dir: sac_models
 agent_type: SAC
 seed: 42
 
+# Resources for Ray Tune trials (optional)
+resources_per_trial:
+  cpu: 1
+  gpu: 0
+
 env:
   continuous: true
 

--- a/train.py
+++ b/train.py
@@ -133,8 +133,13 @@ def run_hpo(base_config, project=None):
 
     param_space = {"agent": {k: tune.grid_search(v) for k, v in space.items()}}
 
+    resources = base_config.get("resources_per_trial")
+    trainable = tune.with_parameters(_tune_train, base_config=base_config, project=project)
+    if resources:
+        trainable = tune.with_resources(trainable, resources=resources)
+
     tuner = tune.Tuner(
-        tune.with_parameters(_tune_train, base_config=base_config, project=project),
+        trainable,
         param_space=param_space,
     )
     results = tuner.fit()


### PR DESCRIPTION
## Summary
- allow setting resources per Ray Tune trial
- wrap tuning trainable with `tune.with_resources`
- document the new option and show sample block
- add `resources_per_trial` defaults in example configs

## Testing
- `python -m py_compile train.py agent.py ppo_agent.py sac_agent.py buffer.py exploration.py car_racing_env.py model.py ray_env.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68516aecc138832b97b612de238c861f