### PR TITLE
Allow concurrency config with fractional GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,13 @@ The DQN agent uses a prioritized replay buffer by default for more efficient lea
 
 Add `--hpo` to automatically explore recommended hyperparameters using **Ray Tune**.
 Results can be logged to Weights & Biases with `--wandb_project <project>`.
-Resource allocation for each Tune trial can be adjusted via a `resources_per_trial` section in the config file.
+Resource allocation for each Tune trial can be adjusted via a `resources_per_trial` section in the config file. Concurrency can also be limited with `max_concurrent_trials`.
 
 ```yaml
+max_concurrent_trials: 4
 resources_per_trial:
-  cpu: 1
-  gpu: 0
+  cpu: 5
+  gpu: 0.15
 ```
 
 ```bash

--- a/config.yaml
+++ b/config.yaml
@@ -9,9 +9,10 @@ agent_type: DQN
 seed: 42
 
 # Resources for Ray Tune trials (optional)
+max_concurrent_trials: 4
 resources_per_trial:
-  cpu: 1
-  gpu: 0
+  cpu: 5
+  gpu: 0.15
 
 env:
   continuous: false

--- a/dqn_config.yaml
+++ b/dqn_config.yaml
@@ -9,9 +9,10 @@ agent_type: DQN
 seed: 42
 
 # Resources for Ray Tune trials (optional)
+max_concurrent_trials: 4
 resources_per_trial:
-  cpu: 1
-  gpu: 0
+  cpu: 5
+  gpu: 0.15
 
 env:
   continuous: false

--- a/ppo_config.yaml
+++ b/ppo_config.yaml
@@ -9,9 +9,10 @@ agent_type: PPO
 seed: 42
 
 # Resources for Ray Tune trials (optional)
+max_concurrent_trials: 4
 resources_per_trial:
-  cpu: 1
-  gpu: 0
+  cpu: 5
+  gpu: 0.15
 
 env:
   continuous: false

--- a/sac_config.yaml
+++ b/sac_config.yaml
@@ -9,9 +9,10 @@ agent_type: SAC
 seed: 42
 
 # Resources for Ray Tune trials (optional)
+max_concurrent_trials: 4
 resources_per_trial:
-  cpu: 1
-  gpu: 0
+  cpu: 5
+  gpu: 0.15
 
 env:
   continuous: true

--- a/train.py
+++ b/train.py
@@ -138,9 +138,15 @@ def run_hpo(base_config, project=None):
     if resources:
         trainable = tune.with_resources(trainable, resources=resources)
 
+    max_concurrent = base_config.get("max_concurrent_trials")
+    tune_cfg = None
+    if max_concurrent:
+        tune_cfg = tune.TuneConfig(max_concurrent_trials=max_concurrent)
+
     tuner = tune.Tuner(
         trainable,
         param_space=param_space,
+        tune_config=tune_cfg,
     )
     results = tuner.fit()
     best = results.get_best_result(metric="score", mode="max")


### PR DESCRIPTION
## Summary
- expose `max_concurrent_trials` in `run_hpo`
- document concurrency and fractional GPU resources
- update example configs with 4 concurrent trials using 5 CPUs and 0.15 GPU each

## Testing
- `python -m py_compile train.py`
- `python train.py --help` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685169dc55bc832ba3049a8e225a3eb0